### PR TITLE
read schema name from settings

### DIFF
--- a/lib/discoverer.js
+++ b/lib/discoverer.js
@@ -158,10 +158,10 @@ Discoverer.prototype.discoverModels = function(overwrite, cb) {
     }
   };
 
-  self.dataSource.connector.discoverModelDefinitions(function(err, tables) {
-    if (err !== null)
+  self.dataSource.connector.discoverModelDefinitions({ schema: self.dataSource.settings.database },function(err, tables) {
+    if (err) {
       cb(err);
-    else {
+    } else {
       list.tables = tables;
       discoverModelFromList(self.dataSource, list, saveModel);
     }


### PR DESCRIPTION
Hello, I tried generating models from a MySQL datasource but discovery always returned an empty Array. I explicitly added the schema name and it works now.

regards,
